### PR TITLE
Added an of(size:) method to the Font enum.

### DIFF
--- a/UIFontComplete/Font.swift
+++ b/UIFontComplete/Font.swift
@@ -397,4 +397,15 @@ public enum Font: String {
     case bodoniSvtyTwoOSITCTTBook = "BodoniSvtyTwoOSITCTT-Book"
     case bodoniSvtyTwoOSITCTTBold = "BodoniSvtyTwoOSITCTT-Bold"
     case bodoniSvtyTwoOSITCTTBookIt = "BodoniSvtyTwoOSITCTT-BookIt"
+
+    /// An alternative way to get a particular `UIFont` instance from a `Font`
+    /// value.
+    ///
+    /// - parameter of size: The desired size of the font.
+    ///
+    /// - returns a `UIFont` instance of the desired font family and size, or
+    /// `nil` if the font family or size isn't installed.
+    public func of(size: CGFloat) -> UIFont? {
+        return UIFont(name: rawValue, size: size)
+    }
 }

--- a/UIFontCompleteTests/UIFontCompleteTests.swift
+++ b/UIFontCompleteTests/UIFontCompleteTests.swift
@@ -1002,4 +1002,8 @@ class UIFontCompleteTests: XCTestCase {
     func testFontBodonisvtytwoositcttbookit() {
         XCTAssert(UIFont(font: .bodoniSvtyTwoOSITCTTBookIt, size: 12.0) != nil, "Font \"BodoniSvtyTwoOSITCTT-BookIt\" can not be found.")
     }
+
+    func testOfSize() {
+        XCTAssertNotNil(Font.helvetica.of(size: 12.0))
+    }
 }


### PR DESCRIPTION
Added a utility method, `of(size:)`, to the `Font` enum so that you can get a `UIFont` instance right from the enum value.