### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ xcode_project: UIFontComplete.xcodeproj # path to your xcodeproj folder
 xcode_scheme: UIFontComplete
 
 script:
-  - xcodebuild test -scheme UIFontComplete -sdk iphonesimulator -destination 'id=47B400BF-57B2-4119-9811-6359FF86A51D'
+  - xcodebuild test -scheme UIFontComplete -sdk iphonesimulator -destination 'OS=10.3,name=iPhone 7 Plus'
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Travis CI sometimes has multiple simulator options for the same `OS` and device `name` so not specifying an explicit `id`
would sometimes cause an ambiguity but recently that issue seems to have been fixed. 

Not explicitly specifying an `id` is more flexible and CI should break less often.