### PR TITLE
Consolidation and organization of `Font.swift`

### DIFF
--- a/Sources/Font.swift
+++ b/Sources/Font.swift
@@ -22,653 +22,458 @@
 public enum Font: String, FontRepresentable {
 
     #if os(iOS)
-    /*
-     📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱
-                        iOS Fonts
-     📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱📱
-    */
-
-    // Academy Engraved LET
+    
+    // MARK: Academy Engraved LET
     case academyEngravedLetPlain = "AcademyEngravedLetPlain"
 
-    // Al Nile
-    case alNileBold = "AlNile-Bold"
+    // MARK: Al Nile
     case alNile = "AlNile"
+    case alNileBold = "AlNile-Bold"
 
-    // American Typewriter
-    case americanTypewriterCondensedLight = "AmericanTypewriter-CondensedLight"
+    #endif
+    
+    // MARK: American Typewriter
     case americanTypewriter = "AmericanTypewriter"
-    case americanTypewriterCondensedBold = "AmericanTypewriter-CondensedBold"
-    case americanTypewriterLight = "AmericanTypewriter-Light"
-    case americanTypewriterSemibold = "AmericanTypewriter-Semibold"
     case americanTypewriterBold = "AmericanTypewriter-Bold"
     case americanTypewriterCondensed = "AmericanTypewriter-Condensed"
+    case americanTypewriterCondensedBold = "AmericanTypewriter-CondensedBold"
+    case americanTypewriterCondensedLight = "AmericanTypewriter-CondensedLight"
+    case americanTypewriterLight = "AmericanTypewriter-Light"
+    case americanTypewriterSemibold = "AmericanTypewriter-Semibold"
 
-    // Apple Color Emoji
+    // MARK: Apple Color Emoji
     case appleColorEmoji = "AppleColorEmoji"
 
-    // Apple SD Gothic Neo
+    // MARK: Apple SD Gothic Neo
     case appleSDGothicNeoBold = "AppleSDGothicNeo-Bold"
-    case appleSDGothicNeoUltraLight = "AppleSDGothicNeo-UltraLight"
-    case appleSDGothicNeoThin = "AppleSDGothicNeo-Thin"
-    case appleSDGothicNeoRegular = "AppleSDGothicNeo-Regular"
     case appleSDGothicNeoLight = "AppleSDGothicNeo-Light"
     case appleSDGothicNeoMedium = "AppleSDGothicNeo-Medium"
+    case appleSDGothicNeoRegular = "AppleSDGothicNeo-Regular"
     case appleSDGothicNeoSemiBold = "AppleSDGothicNeo-SemiBold"
+    case appleSDGothicNeoThin = "AppleSDGothicNeo-Thin"
+    case appleSDGothicNeoUltraLight = "AppleSDGothicNeo-UltraLight"
 
-    // Arial
+    #if os(iOS)
+    
+    // MARK: Arial
     case arialMT = "ArialMT"
     case arialBoldItalicMT = "Arial-BoldItalicMT"
     case arialBoldMT = "Arial-BoldMT"
     case arialItalicMT = "Arial-ItalicMT"
-
-    // Arial Hebrew
+    
+    #endif
+    
+    // MARK: Arial Hebrew
+    case arialHebrew = "ArialHebrew"
     case arialHebrewBold = "ArialHebrew-Bold"
     case arialHebrewLight = "ArialHebrew-Light"
-    case arialHebrew = "ArialHebrew"
 
     // Arial Rounded MT Bold
     case arialRoundedMTBold = "ArialRoundedMTBold"
 
-    // Avenir
-    case avenirMedium = "Avenir-Medium"
-    case avenirHeavyOblique = "Avenir-HeavyOblique"
-    case avenirBook = "Avenir-Book"
-    case avenirLight = "Avenir-Light"
-    case avenirRoman = "Avenir-Roman"
-    case avenirBookOblique = "Avenir-BookOblique"
-    case avenirMediumOblique = "Avenir-MediumOblique"
+    // MARK: Avenir
     case avenirBlack = "Avenir-Black"
     case avenirBlackOblique = "Avenir-BlackOblique"
+    case avenirBook = "Avenir-Book"
+    case avenirBookOblique = "Avenir-BookOblique"
     case avenirHeavy = "Avenir-Heavy"
+    case avenirHeavyOblique = "Avenir-HeavyOblique"
+    case avenirLight = "Avenir-Light"
     case avenirLightOblique = "Avenir-LightOblique"
+    case avenirMedium = "Avenir-Medium"
+    case avenirMediumOblique = "Avenir-MediumOblique"
     case avenirOblique = "Avenir-Oblique"
+    case avenirRoman = "Avenir-Roman"
 
-    // Avenir Next
-    case avenirNextUltraLight = "AvenirNext-UltraLight"
-    case avenirNextUltraLightItalic = "AvenirNext-UltraLightItalic"
+    // MARK: Avenir Next
     case avenirNextBold = "AvenirNext-Bold"
     case avenirNextBoldItalic = "AvenirNext-BoldItalic"
     case avenirNextDemiBold = "AvenirNext-DemiBold"
     case avenirNextDemiBoldItalic = "AvenirNext-DemiBoldItalic"
-    case avenirNextMedium = "AvenirNext-Medium"
-    case avenirNextHeavyItalic = "AvenirNext-HeavyItalic"
     case avenirNextHeavy = "AvenirNext-Heavy"
+    case avenirNextHeavyItalic = "AvenirNext-HeavyItalic"
     case avenirNextItalic = "AvenirNext-Italic"
-    case avenirNextRegular = "AvenirNext-Regular"
+    case avenirNextMedium = "AvenirNext-Medium"
     case avenirNextMediumItalic = "AvenirNext-MediumItalic"
+    case avenirNextRegular = "AvenirNext-Regular"
+    case avenirNextUltraLight = "AvenirNext-UltraLight"
+    case avenirNextUltraLightItalic = "AvenirNext-UltraLightItalic"
 
-    // Avenir Next Condensed
-    case avenirNextCondensedBoldItalic = "AvenirNextCondensed-BoldItalic"
-    case avenirNextCondensedHeavy = "AvenirNextCondensed-Heavy"
-    case avenirNextCondensedMedium = "AvenirNextCondensed-Medium"
-    case avenirNextCondensedRegular = "AvenirNextCondensed-Regular"
-    case avenirNextCondensedHeavyItalic = "AvenirNextCondensed-HeavyItalic"
-    case avenirNextCondensedMediumItalic = "AvenirNextCondensed-MediumItalic"
-    case avenirNextCondensedItalic = "AvenirNextCondensed-Italic"
-    case avenirNextCondensedUltraLightItalic = "AvenirNextCondensed-UltraLightItalic"
-    case avenirNextCondensedUltraLight = "AvenirNextCondensed-UltraLight"
-    case avenirNextCondensedDemiBold = "AvenirNextCondensed-DemiBold"
+    #if os(iOS)
+    
+    // MARK: Avenir Next Condensed
     case avenirNextCondensedBold = "AvenirNextCondensed-Bold"
+    case avenirNextCondensedBoldItalic = "AvenirNextCondensed-BoldItalic"
+    case avenirNextCondensedDemiBold = "AvenirNextCondensed-DemiBold"
     case avenirNextCondensedDemiBoldItalic = "AvenirNextCondensed-DemiBoldItalic"
-
-    // Baskerville
+    case avenirNextCondensedHeavy = "AvenirNextCondensed-Heavy"
+    case avenirNextCondensedHeavyItalic = "AvenirNextCondensed-HeavyItalic"
+    case avenirNextCondensedItalic = "AvenirNextCondensed-Italic"
+    case avenirNextCondensedMedium = "AvenirNextCondensed-Medium"
+    case avenirNextCondensedMediumItalic = "AvenirNextCondensed-MediumItalic"
+    case avenirNextCondensedRegular = "AvenirNextCondensed-Regular"
+    case avenirNextCondensedUltraLight = "AvenirNextCondensed-UltraLight"
+    case avenirNextCondensedUltraLightItalic = "AvenirNextCondensed-UltraLightItalic"
+    
+    #endif
+    
+    // MARK: Baskerville
+    case baskerville = "Baskerville"
+    case baskervilleBold = "Baskerville-Bold"
+    case baskervilleBoldItalic = "Baskerville-BoldItalic"
     case baskervilleItalic = "Baskerville-Italic"
     case baskervilleSemiBold = "Baskerville-SemiBold"
-    case baskervilleBoldItalic = "Baskerville-BoldItalic"
     case baskervilleSemiBoldItalic = "Baskerville-SemiBoldItalic"
-    case baskervilleBold = "Baskerville-Bold"
-    case baskerville = "Baskerville"
 
-    // Bodoni 72
+    #if os(iOS)
+    
+    // MARK: Bodoni 72
     case bodoniSvtyTwoITCTTBold = "BodoniSvtyTwoITCTT-Bold"
     case bodoniSvtyTwoITCTTBook = "BodoniSvtyTwoITCTT-Book"
     case bodoniSvtyTwoITCTTBookIta = "BodoniSvtyTwoITCTT-BookIta"
 
-    // Bodoni 72 Oldstyle
-    case bodoniSvtyTwoOSITCTTBook = "BodoniSvtyTwoOSITCTT-Book"
+    // MARK: Bodoni 72 Oldstyle
     case bodoniSvtyTwoOSITCTTBold = "BodoniSvtyTwoOSITCTT-Bold"
+    case bodoniSvtyTwoOSITCTTBook = "BodoniSvtyTwoOSITCTT-Book"
     case bodoniSvtyTwoOSITCTTBookIt = "BodoniSvtyTwoOSITCTT-BookIt"
 
-    // Bodoni 72 Smallcaps
+    // MARK: Bodoni 72 Smallcaps
     case bodoniSvtyTwoSCITCTTBook = "BodoniSvtyTwoSCITCTT-Book"
 
-    // Bodoni Ornaments
+    // MARK: Bodoni Ornaments
     case bodoniOrnamentsITCTT = "BodoniOrnamentsITCTT"
 
-    // Bradley Hand
+    // MARK: Bradley Hand
     case bradleyHandITCTTBold = "BradleyHandITCTT-Bold"
 
-    // Chalkboard SE
+    // MARK: Chalkboard SE
     case chalkboardSEBold = "ChalkboardSE-Bold"
     case chalkboardSELight = "ChalkboardSE-Light"
     case chalkboardSERegular = "ChalkboardSE-Regular"
 
-    // Chalkduster
+    // MARK: Chalkduster
     case chalkduster = "Chalkduster"
 
-    // Cochin
-    case cochinBold = "Cochin-Bold"
+    // MARK: Cochin
     case cochin = "Cochin"
-    case cochinItalic = "Cochin-Italic"
+    case cochinBold = "Cochin-Bold"
     case cochinBoldItalic = "Cochin-BoldItalic"
-
-    // Copperplate
-    case copperplateLight = "Copperplate-Light"
+    case cochinItalic = "Cochin-Italic"
+    
+    #endif
+    
+    // MARK: Copperplate
     case copperplate = "Copperplate"
     case copperplateBold = "Copperplate-Bold"
+    case copperplateLight = "Copperplate-Light"
 
-    // Courier
-    case courierBoldOblique = "Courier-BoldOblique"
+    // MARK: Courier
     case courier = "Courier"
     case courierBold = "Courier-Bold"
+    case courierBoldOblique = "Courier-BoldOblique"
     case courierOblique = "Courier-Oblique"
 
-    // Courier New
-    case courierNewPSBoldMT = "CourierNewPS-BoldMT"
-    case courierNewPSItalicMT = "CourierNewPS-ItalicMT"
+    // MARK: Courier New
     case courierNewPSMT = "CourierNewPSMT"
+    case courierNewPSBoldMT = "CourierNewPS-BoldMT"
     case courierNewPSBoldItalicMT = "CourierNewPS-BoldItalicMT"
+    case courierNewPSItalicMT = "CourierNewPS-ItalicMT"
 
-    // Damascus
-    case damascusLight = "DamascusLight"
-    case damascusBold = "DamascusBold"
-    case damascusSemiBold = "DamascusSemiBold"
-    case damascusMedium = "DamascusMedium"
+    #if os(iOS)
+    
+    // MARK: Damascus
     case damascus = "Damascus"
+    case damascusBold = "DamascusBold"
+    case damascusLight = "DamascusLight"
+    case damascusMedium = "DamascusMedium"
+    case damascusSemiBold = "DamascusSemiBold"
 
-    // Devanagari Sangam MN
+    // MARK: Devanagari Sangam MN
     case devanagariSangamMN = "DevanagariSangamMN"
     case devanagariSangamMNBold = "DevanagariSangamMN-Bold"
 
-    // Didot
-    case didotItalic = "Didot-Italic"
-    case didotBold = "Didot-Bold"
+    // MARK: Didot
     case didot = "Didot"
+    case didotBold = "Didot-Bold"
+    case didotItalic = "Didot-Italic"
+    
+    // MARK: Diwan Mishafi
+    case diwanMishafi = "DiwanMishafi"
+    
+    #endif
 
-    // Euphemia UCAS
-    case euphemiaUCASItalic = "EuphemiaUCAS-Italic"
+    // MARK: Euphemia UCAS
     case euphemiaUCAS = "EuphemiaUCAS"
     case euphemiaUCASBold = "EuphemiaUCAS-Bold"
+    case euphemiaUCASItalic = "EuphemiaUCAS-Italic"
 
-    // Farah
+    #if os(iOS)
+    
+    // MARK: Farah
     case farah = "Farah"
+    
+    #endif
 
-    // Futura
-    case futuraCondensedMedium = "Futura-CondensedMedium"
+    // MARK: Futura
+    case futuraBold = "Futura-Bold"
     case futuraCondensedExtraBold = "Futura-CondensedExtraBold"
+    case futuraCondensedMedium = "Futura-CondensedMedium"
     case futuraMedium = "Futura-Medium"
     case futuraMediumItalic = "Futura-MediumItalic"
-    case futuraBold = "Futura-Bold"
 
-    // Geeza Pro
+    // MARK: Geeza Pro
     case geezaPro = "GeezaPro"
     case geezaProBold = "GeezaPro-Bold"
 
-    // Georgia
-    case georgiaBoldItalic = "Georgia-BoldItalic"
+    #if os(iOS)
+    // MARK: Georgia
     case georgia = "Georgia"
-    case georgiaItalic = "Georgia-Italic"
     case georgiaBold = "Georgia-Bold"
+    case georgiaBoldItalic = "Georgia-BoldItalic"
+    case georgiaItalic = "Georgia-Italic"
 
     // Gill Sans
-    case gillSansItalic = "GillSans-Italic"
+    case gillSans = "GillSans"
     case gillSansBold = "GillSans-Bold"
     case gillSansBoldItalic = "GillSans-BoldItalic"
-    case gillSansLightItalic = "GillSans-LightItalic"
-    case gillSans = "GillSans"
+    case gillSansItalic = "GillSans-Italic"
     case gillSansLight = "GillSans-Light"
+    case gillSansLightItalic = "GillSans-LightItalic"
     case gillSansSemiBold = "GillSans-SemiBold"
     case gillSansSemiBoldItalic = "GillSans-SemiBoldItalic"
     case gillSansUltraBold = "GillSans-UltraBold"
+    
+    #endif
 
-    // Gujarati Sangam MN
-    case gujaratiSangamMNBold = "GujaratiSangamMN-Bold"
+    // MARK: Gujarati Sangam MN
     case gujaratiSangamMN = "GujaratiSangamMN"
-
-    // Gurmukhi MN
-    case gurmukhiMNBold = "GurmukhiMN-Bold"
+    case gujaratiSangamMNBold = "GujaratiSangamMN-Bold"
+    
+    // MARK: Gurmukhi MN
     case gurmukhiMN = "GurmukhiMN"
+    case gurmukhiMNBold = "GurmukhiMN-Bold"
 
-    // Helvetica
-    case helveticaBold = "Helvetica-Bold"
+    // MARK: Helvetica
     case helvetica = "Helvetica"
-    case helveticaLightOblique = "Helvetica-LightOblique"
-    case helveticaOblique = "Helvetica-Oblique"
+    case helveticaBold = "Helvetica-Bold"
     case helveticaBoldOblique = "Helvetica-BoldOblique"
     case helveticaLight = "Helvetica-Light"
+    case helveticaLightOblique = "Helvetica-LightOblique"
+    case helveticaOblique = "Helvetica-Oblique"
 
-    // Helvetica Neue
-    case helveticaNeueItalic = "HelveticaNeue-Italic"
-    case helveticaNeueBold = "HelveticaNeue-Bold"
-    case helveticaNeueUltraLight = "HelveticaNeue-UltraLight"
+    // MARK: Helvetica Neue
+    case helveticaNeue = "HelveticaNeue"
     case helveticaNeueCondensedBlack = "HelveticaNeue-CondensedBlack"
-    case helveticaNeueBoldItalic = "HelveticaNeue-BoldItalic"
     case helveticaNeueCondensedBold = "HelveticaNeue-CondensedBold"
-    case helveticaNeueMedium = "HelveticaNeue-Medium"
+    case helveticaNeueBold = "HelveticaNeue-Bold"
+    case helveticaNeueBoldItalic = "HelveticaNeue-BoldItalic"
+    case helveticaNeueItalic = "HelveticaNeue-Italic"
     case helveticaNeueLight = "HelveticaNeue-Light"
+    case helveticaNeueLightItalic = "HelveticaNeue-LightItalic"
+    case helveticaNeueMedium = "HelveticaNeue-Medium"
+    case helveticaNeueMediumItalic = "HelveticaNeue-MediumItalic"
     case helveticaNeueThin = "HelveticaNeue-Thin"
     case helveticaNeueThinItalic = "HelveticaNeue-ThinItalic"
-    case helveticaNeueLightItalic = "HelveticaNeue-LightItalic"
+    case helveticaNeueUltraLight = "HelveticaNeue-UltraLight"
     case helveticaNeueUltraLightItalic = "HelveticaNeue-UltraLightItalic"
-    case helveticaNeueMediumItalic = "HelveticaNeue-MediumItalic"
-    case helveticaNeue = "HelveticaNeue"
 
-    // Hiragino Mincho ProN
-    case hiraMinProNW6 = "HiraMinProN-W6"
+    #if os(iOS)
+    
+    // MARK: Hiragino Mincho ProN
     case hiraMinProNW3 = "HiraMinProN-W3"
+    case hiraMinProNW6 = "HiraMinProN-W6"
 
-    // Hiragino Sans
+    #elseif os(tvOS)
+    
+    case hiraMaruProNW4 = "HiraMaruProN-W4"
+    
+    #endif
+    
+    //  MARK:Hiragino Sans
+    
     case hiraginoSansW3 = "HiraginoSans-W3"
+    
+    #if os(tvOS)
+    
+    case hiraginoSansW5 = "HiraginoSans-W5"
+    
+    #endif
+    
     case hiraginoSansW6 = "HiraginoSans-W6"
 
-    // Hoefler Text
-    case hoeflerTextItalic = "HoeflerText-Italic"
-    case hoeflerTextRegular = "HoeflerText-Regular"
+    #if os(iOS)
+    
+    //  MARK:Hoefler Text
     case hoeflerTextBlack = "HoeflerText-Black"
     case hoeflerTextBlackItalic = "HoeflerText-BlackItalic"
+    case hoeflerTextItalic = "HoeflerText-Italic"
+    case hoeflerTextRegular = "HoeflerText-Regular"
 
-    // Kailasa
-    case kailasaBold = "Kailasa-Bold"
+    #endif
+
+    // MARK: Kailasa
     case kailasa = "Kailasa"
+    case kailasaBold = "Kailasa-Bold"
 
-    // Kannada Sangam MN
+    //  MARK:Kannada Sangam MN
     case kannadaSangamMN = "KannadaSangamMN"
     case kannadaSangamMNBold = "KannadaSangamMN-Bold"
 
-    // Khmer Sangam MN
+    #if os(tvOS)
+    
+    // MARK: Kefa
+    case kefaRegular = "Kefa-Regular"
+    
+    #endif
+    
+    // MARK: Khmer Sangam MN
     case khmerSangamMN = "KhmerSangamMN"
 
-    // Kohinoor Bangla
-    case kohinoorBanglaSemibold = "KohinoorBangla-Semibold"
-    case kohinoorBanglaRegular = "KohinoorBangla-Regular"
+    // MARK: Kohinoor Bangla
     case kohinoorBanglaLight = "KohinoorBangla-Light"
+    case kohinoorBanglaRegular = "KohinoorBangla-Regular"
+    case kohinoorBanglaSemibold = "KohinoorBangla-Semibold"
 
-    // Kohinoor Devanagari
+    // MARK: Kohinoor Devanagari
     case kohinoorDevanagariLight = "KohinoorDevanagari-Light"
     case kohinoorDevanagariRegular = "KohinoorDevanagari-Regular"
     case kohinoorDevanagariSemibold = "KohinoorDevanagari-Semibold"
 
-    // Kohinoor Telugu
-    case kohinoorTeluguRegular = "KohinoorTelugu-Regular"
-    case kohinoorTeluguMedium = "KohinoorTelugu-Medium"
+    // MARK: Kohinoor Telugu
     case kohinoorTeluguLight = "KohinoorTelugu-Light"
+    case kohinoorTeluguMedium = "KohinoorTelugu-Medium"
+    case kohinoorTeluguRegular = "KohinoorTelugu-Regular"
 
-    // Lao Sangam MN
+    // MARK: Lao Sangam MN
     case laoSangamMN = "LaoSangamMN"
 
-    // Malayalam Sangam MN
-    case malayalamSangamMNBold = "MalayalamSangamMN-Bold"
+    // MARK: Malayalam Sangam MN
     case malayalamSangamMN = "MalayalamSangamMN"
+    case malayalamSangamMNBold = "MalayalamSangamMN-Bold"
 
-    // Marker Felt
+    #if os(iOS)
+    
+    // MARK: Marker Felt
     case markerFeltThin = "MarkerFelt-Thin"
     case markerFeltWide = "MarkerFelt-Wide"
+    
+    #endif
 
-    // Menlo
-    case menloItalic = "Menlo-Italic"
+    // MARK: Menlo
     case menloBold = "Menlo-Bold"
-    case menloRegular = "Menlo-Regular"
     case menloBoldItalic = "Menlo-BoldItalic"
+    case menloItalic = "Menlo-Italic"
+    case menloRegular = "Menlo-Regular"
 
-    // Mishafi
-    case diwanMishafi = "DiwanMishafi"
-
-    // Myanmar Sangam MN
-    case myanmarSangamMNBold = "MyanmarSangamMN-Bold"
+    // MARK: Myanmar Sangam MN
     case myanmarSangamMN = "MyanmarSangamMN"
+    case myanmarSangamMNBold = "MyanmarSangamMN-Bold"
 
-    // Noteworthy
-    case noteworthyLight = "Noteworthy-Light"
+    // MARK: Noteworthy
     case noteworthyBold = "Noteworthy-Bold"
+    case noteworthyLight = "Noteworthy-Light"
 
-    // Optima
-    case optimaRegular = "Optima-Regular"
-    case optimaExtraBlack = "Optima-ExtraBlack"
-    case optimaBoldItalic = "Optima-BoldItalic"
-    case optimaItalic = "Optima-Italic"
+    #if os(tvOS)
+    
+    // MARK: Noto Nastaliq Urdu
+    case notoNastaliqUrdu = "NotoNastaliqUrdu"
+    
+    #endif
+    
+    // MARK: Optima
     case optimaBold = "Optima-Bold"
+    case optimaBoldItalic = "Optima-BoldItalic"
+    case optimaExtraBlack = "Optima-ExtraBlack"
+    case optimaItalic = "Optima-Italic"
+    case optimaRegular = "Optima-Regular"
 
-    // Oriya Sangam MN
+    // MARK: Oriya Sangam MN
     case oriyaSangamMN = "OriyaSangamMN"
     case oriyaSangamMNBold = "OriyaSangamMN-Bold"
 
-    // Palatino
+    // MARK: Palatino
     case palatinoBold = "Palatino-Bold"
-    case palatinoRoman = "Palatino-Roman"
     case palatinoBoldItalic = "Palatino-BoldItalic"
     case palatinoItalic = "Palatino-Italic"
+    case palatinoRoman = "Palatino-Roman"
 
-    // Papyrus
+    // MARK: Papyrus
     case papyrus = "Papyrus"
     case papyrusCondensed = "Papyrus-Condensed"
 
-    // Party LET
+    // MARK: Party LET
     case partyLetPlain = "PartyLetPlain"
 
-    // PingFang HK
-    case pingFangHKUltralight = "PingFangHK-Ultralight"
+    // MARK: PingFang HK
+    case pingFangHKLight = "PingFangHK-Light"
+    case pingFangHKMedium = "PingFangHK-Medium"
+    case pingFangHKRegular = "PingFangHK-Regular"
     case pingFangHKSemibold = "PingFangHK-Semibold"
     case pingFangHKThin = "PingFangHK-Thin"
-    case pingFangHKLight = "PingFangHK-Light"
-    case pingFangHKRegular = "PingFangHK-Regular"
-    case pingFangHKMedium = "PingFangHK-Medium"
+    case pingFangHKUltralight = "PingFangHK-Ultralight"
 
-    // PingFang SC
-    case pingFangSCUltralight = "PingFangSC-Ultralight"
+    // MARK: PingFang SC
+    case pingFangSCLight = "PingFangSC-Light"
+    case pingFangSCMedium = "PingFangSC-Medium"
     case pingFangSCRegular = "PingFangSC-Regular"
     case pingFangSCSemibold = "PingFangSC-Semibold"
     case pingFangSCThin = "PingFangSC-Thin"
-    case pingFangSCLight = "PingFangSC-Light"
-    case pingFangSCMedium = "PingFangSC-Medium"
+    case pingFangSCUltralight = "PingFangSC-Ultralight"
 
-    // PingFang TC
+    // MARK: PingFang TC
+    case pingFangTCLight = "PingFangTC-Light"
     case pingFangTCMedium = "PingFangTC-Medium"
     case pingFangTCRegular = "PingFangTC-Regular"
-    case pingFangTCLight = "PingFangTC-Light"
-    case pingFangTCUltralight = "PingFangTC-Ultralight"
     case pingFangTCSemibold = "PingFangTC-Semibold"
     case pingFangTCThin = "PingFangTC-Thin"
+    case pingFangTCUltralight = "PingFangTC-Ultralight"
 
-    // Savoye LET
+    // MARK: Savoye LET
     case savoyeLetPlain = "SavoyeLetPlain"
 
-    // Sinhala Sangam MN
-    case sinhalaSangamMNBold = "SinhalaSangamMN-Bold"
+    // MARK: Sinhala Sangam MN
     case sinhalaSangamMN = "SinhalaSangamMN"
+    case sinhalaSangamMNBold = "SinhalaSangamMN-Bold"
 
-    // Snell Roundhand
-    case snellRoundhandBold = "SnellRoundhand-Bold"
+    // MARK: Snell Roundhand
     case snellRoundhand = "SnellRoundhand"
     case snellRoundhandBlack = "SnellRoundhand-Black"
+    case snellRoundhandBold = "SnellRoundhand-Bold"
 
-    // Symbol
+    // MARK: Symbol
     case symbol = "Symbol"
 
-    // Tamil Sangam MN
+    // MARK: Tamil Sangam MN
     case tamilSangamMN = "TamilSangamMN"
     case tamilSangamMNBold = "TamilSangamMN-Bold"
 
-    // Thonburi
+    // MARK: Thonburi
     case thonburi = "Thonburi"
     case thonburiBold = "Thonburi-Bold"
     case thonburiLight = "Thonburi-Light"
 
-    // Times New Roman
-    case timesNewRomanPSMT = "TimesNewRomanPSMT"
+    // MARK: Times New Roman
+    case timesNewRomanPSBoldMT = "TimesNewRomanPS-BoldMT"
     case timesNewRomanPSBoldItalicMT = "TimesNewRomanPS-BoldItalicMT"
     case timesNewRomanPSItalicMT = "TimesNewRomanPS-ItalicMT"
-    case timesNewRomanPSBoldMT = "TimesNewRomanPS-BoldMT"
+    case timesNewRomanPSMT = "TimesNewRomanPSMT"
 
-    // Trebuchet MS
-    case trebuchetBoldItalic = "Trebuchet-BoldItalic"
+    // MARK: Trebuchet MS
     case trebuchetMS = "TrebuchetMS"
     case trebuchetMSBold = "TrebuchetMS-Bold"
+    case trebuchetBoldItalic = "Trebuchet-BoldItalic"
     case trebuchetMSItalic = "TrebuchetMS-Italic"
 
-    // Verdana
-    case verdanaItalic = "Verdana-Italic"
-    case verdanaBoldItalic = "Verdana-BoldItalic"
+    // MARK: Verdana
     case verdana = "Verdana"
     case verdanaBold = "Verdana-Bold"
+    case verdanaBoldItalic = "Verdana-BoldItalic"
+    case verdanaItalic = "Verdana-Italic"
 
-    // Zapf Dingbats
+    // MARK: Zapf Dingbats
     case zapfDingbatsITC = "ZapfDingbatsITC"
 
-    // Zapfino
+    // MARK: Zapfino
     case zapfino = "Zapfino"
 
-    #elseif os(tvOS)
-    /*
-     📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺
-                      tvOS Fonts
-     📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺📺
-    */
-
-    // American Typewriter
-    case americanTypewriterBold = "AmericanTypewriter-Bold"
-    case americanTypewriterCondensedLight = "AmericanTypewriter-CondensedLight"
-    case americanTypewriterSemibold = "AmericanTypewriter-Semibold"
-    case americanTypewriterCondensedBold = "AmericanTypewriter-CondensedBold"
-    case americanTypewriter = "AmericanTypewriter"
-    case americanTypewriterLight = "AmericanTypewriter-Light"
-    case americanTypewriterCondensed = "AmericanTypewriter-Condensed"
-
-    // Apple Color Emoji
-    case appleColorEmoji = "AppleColorEmoji"
-
-    // Apple SD Gothic Neo
-    case appleSDGothicNeoThin = "AppleSDGothicNeo-Thin"
-    case appleSDGothicNeoSemiBold = "AppleSDGothicNeo-SemiBold"
-    case appleSDGothicNeoLight = "AppleSDGothicNeo-Light"
-    case appleSDGothicNeoMedium = "AppleSDGothicNeo-Medium"
-    case appleSDGothicNeoBold = "AppleSDGothicNeo-Bold"
-    case appleSDGothicNeoUltraLight = "AppleSDGothicNeo-UltraLight"
-    case appleSDGothicNeoRegular = "AppleSDGothicNeo-Regular"
-
-    // Arial Hebrew
-    case arialHebrewLight = "ArialHebrew-Light"
-    case arialHebrew = "ArialHebrew"
-    case arialHebrewBold = "ArialHebrew-Bold"
-
-    // Avenir
-    case avenirBook = "Avenir-Book"
-    case avenirHeavy = "Avenir-Heavy"
-    case avenirBlackOblique = "Avenir-BlackOblique"
-    case avenirBlack = "Avenir-Black"
-    case avenirLightOblique = "Avenir-LightOblique"
-    case avenirLight = "Avenir-Light"
-    case avenirBookOblique = "Avenir-BookOblique"
-    case avenirMedium = "Avenir-Medium"
-    case avenirHeavyOblique = "Avenir-HeavyOblique"
-    case avenirOblique = "Avenir-Oblique"
-    case avenirRoman = "Avenir-Roman"
-    case avenirMediumOblique = "Avenir-MediumOblique"
-
-    // Avenir Next
-    case avenirNextDemiBold = "AvenirNext-DemiBold"
-    case avenirNextUltraLight = "AvenirNext-UltraLight"
-    case avenirNextRegular = "AvenirNext-Regular"
-    case avenirNextHeavyItalic = "AvenirNext-HeavyItalic"
-    case avenirNextBoldItalic = "AvenirNext-BoldItalic"
-    case avenirNextMediumItalic = "AvenirNext-MediumItalic"
-    case avenirNextItalic = "AvenirNext-Italic"
-    case avenirNextHeavy = "AvenirNext-Heavy"
-    case avenirNextDemiBoldItalic = "AvenirNext-DemiBoldItalic"
-    case avenirNextBold = "AvenirNext-Bold"
-    case avenirNextUltraLightItalic = "AvenirNext-UltraLightItalic"
-    case avenirNextMedium = "AvenirNext-Medium"
-
-    // Baskerville
-    case baskervilleSemiBoldItalic = "Baskerville-SemiBoldItalic"
-    case baskervilleSemiBold = "Baskerville-SemiBold"
-    case baskerville = "Baskerville"
-    case baskervilleBoldItalic = "Baskerville-BoldItalic"
-    case baskervilleItalic = "Baskerville-Italic"
-    case baskervilleBold = "Baskerville-Bold"
-
-    // Copperplate
-    case copperplate = "Copperplate"
-    case copperplateLight = "Copperplate-Light"
-    case copperplateBold = "Copperplate-Bold"
-
-    // Courier
-    case courierBoldOblique = "Courier-BoldOblique"
-    case courier = "Courier"
-    case courierBold = "Courier-Bold"
-    case courierOblique = "Courier-Oblique"
-
-    // Courier New
-    case courierNewPSMT = "CourierNewPSMT"
-    case courierNewPSBoldItalicMT = "CourierNewPS-BoldItalicMT"
-    case courierNewPSBoldMT = "CourierNewPS-BoldMT"
-    case courierNewPSItalicMT = "CourierNewPS-ItalicMT"
-
-    // Euphemia UCAS
-    case euphemiaUCAS = "EuphemiaUCAS"
-    case euphemiaUCASBold = "EuphemiaUCAS-Bold"
-    case euphemiaUCASItalic = "EuphemiaUCAS-Italic"
-
-    // Futura
-    case futuraBold = "Futura-Bold"
-    case futuraMediumItalic = "Futura-MediumItalic"
-    case futuraCondensedExtraBold = "Futura-CondensedExtraBold"
-    case futuraCondensedMedium = "Futura-CondensedMedium"
-    case futuraMedium = "Futura-Medium"
-
-    // Geeza Pro
-    case geezaProBold = "GeezaPro-Bold"
-    case geezaPro = "GeezaPro"
-
-    // Gujarati Sangam MN
-    case gujaratiSangamMNBold = "GujaratiSangamMN-Bold"
-    case gujaratiSangamMN = "GujaratiSangamMN"
-
-    // Gurmukhi MN
-    case gurmukhiMN = "GurmukhiMN"
-    case gurmukhiMNBold = "GurmukhiMN-Bold"
-
-    // Helvetica
-    case helveticaOblique = "Helvetica-Oblique"
-    case helveticaBold = "Helvetica-Bold"
-    case helveticaLightOblique = "Helvetica-LightOblique"
-    case helveticaBoldOblique = "Helvetica-BoldOblique"
-    case helveticaLight = "Helvetica-Light"
-    case helvetica = "Helvetica"
-
-    // Helvetica Neue
-    case helveticaNeueUltraLight = "HelveticaNeue-UltraLight"
-    case helveticaNeueUltraLightItalic = "HelveticaNeue-UltraLightItalic"
-    case helveticaNeueLightItalic = "HelveticaNeue-LightItalic"
-    case helveticaNeue = "HelveticaNeue"
-    case helveticaNeueLight = "HelveticaNeue-Light"
-    case helveticaNeueMediumItalic = "HelveticaNeue-MediumItalic"
-    case helveticaNeueCondensedBold = "HelveticaNeue-CondensedBold"
-    case helveticaNeueCondensedBlack = "HelveticaNeue-CondensedBlack"
-    case helveticaNeueThinItalic = "HelveticaNeue-ThinItalic"
-    case helveticaNeueThin = "HelveticaNeue-Thin"
-    case helveticaNeueMedium = "HelveticaNeue-Medium"
-    case helveticaNeueItalic = "HelveticaNeue-Italic"
-    case helveticaNeueBoldItalic = "HelveticaNeue-BoldItalic"
-    case helveticaNeueBold = "HelveticaNeue-Bold"
-
-    // Hiragino Maru Gothic ProN
-    case hiraMaruProNW4 = "HiraMaruProN-W4"
-
-    // Hiragino Sans
-    case hiraginoSansW5 = "HiraginoSans-W5"
-    case hiraginoSansW6 = "HiraginoSans-W6"
-    case hiraginoSansW3 = "HiraginoSans-W3"
-
-    // Kailasa
-    case kailasa = "Kailasa"
-    case kailasaBold = "Kailasa-Bold"
-
-    // Kannada Sangam MN
-    case kannadaSangamMNBold = "KannadaSangamMN-Bold"
-    case kannadaSangamMN = "KannadaSangamMN"
-
-    // Kefa
-    case kefaRegular = "Kefa-Regular"
-
-    // Khmer Sangam MN
-    case khmerSangamMN = "KhmerSangamMN"
-
-    // Kohinoor Bangla
-    case kohinoorBanglaRegular = "KohinoorBangla-Regular"
-    case kohinoorBanglaSemibold = "KohinoorBangla-Semibold"
-    case kohinoorBanglaLight = "KohinoorBangla-Light"
-
-    // Kohinoor Devanagari
-    case kohinoorDevanagariLight = "KohinoorDevanagari-Light"
-    case kohinoorDevanagariRegular = "KohinoorDevanagari-Regular"
-    case kohinoorDevanagariSemibold = "KohinoorDevanagari-Semibold"
-
-    // Kohinoor Telugu
-    case kohinoorTeluguLight = "KohinoorTelugu-Light"
-    case kohinoorTeluguMedium = "KohinoorTelugu-Medium"
-    case kohinoorTeluguRegular = "KohinoorTelugu-Regular"
-
-    // Lao Sangam MN
-    case laoSangamMN = "LaoSangamMN"
-
-    // Malayalam Sangam MN
-    case malayalamSangamMN = "MalayalamSangamMN"
-    case malayalamSangamMNBold = "MalayalamSangamMN-Bold"
-
-    // Menlo
-    case menloBoldItalic = "Menlo-BoldItalic"
-    case menloItalic = "Menlo-Italic"
-    case menloRegular = "Menlo-Regular"
-    case menloBold = "Menlo-Bold"
-
-    // Myanmar Sangam MN
-    case myanmarSangamMN = "MyanmarSangamMN"
-    case myanmarSangamMNBold = "MyanmarSangamMN-Bold"
-
-    // Noto Nastaliq Urdu
-    case notoNastaliqUrdu = "NotoNastaliqUrdu"
-
-    // Oriya Sangam MN
-    case oriyaSangamMNBold = "OriyaSangamMN-Bold"
-    case oriyaSangamMN = "OriyaSangamMN"
-
-    // PingFang HK
-    case pingFangHKRegular = "PingFangHK-Regular"
-    case pingFangHKMedium = "PingFangHK-Medium"
-    case pingFangHKThin = "PingFangHK-Thin"
-    case pingFangHKSemibold = "PingFangHK-Semibold"
-    case pingFangHKLight = "PingFangHK-Light"
-    case pingFangHKUltralight = "PingFangHK-Ultralight"
-
-    // PingFang SC
-    case pingFangSCRegular = "PingFangSC-Regular"
-    case pingFangSCUltralight = "PingFangSC-Ultralight"
-    case pingFangSCThin = "PingFangSC-Thin"
-    case pingFangSCMedium = "PingFangSC-Medium"
-    case pingFangSCLight = "PingFangSC-Light"
-    case pingFangSCSemibold = "PingFangSC-Semibold"
-
-    // PingFang TC
-    case pingFangTCSemibold = "PingFangTC-Semibold"
-    case pingFangTCMedium = "PingFangTC-Medium"
-    case pingFangTCRegular = "PingFangTC-Regular"
-    case pingFangTCUltralight = "PingFangTC-Ultralight"
-    case pingFangTCLight = "PingFangTC-Light"
-    case pingFangTCThin = "PingFangTC-Thin"
-
-    // Savoye LET
-    case savoyeLetPlain = "SavoyeLetPlain"
-
-    // Sinhala Sangam MN
-    case sinhalaSangamMNBold = "SinhalaSangamMN-Bold"
-    case sinhalaSangamMN = "SinhalaSangamMN"
-
-    // Symbol
-    case symbol = "Symbol"
-
-    // Tamil Sangam MN
-    case tamilSangamMN = "TamilSangamMN"
-    case tamilSangamMNBold = "TamilSangamMN-Bold"
-
-    // Thonburi
-    case thonburi = "Thonburi"
-    case thonburiBold = "Thonburi-Bold"
-    case thonburiLight = "Thonburi-Light"
-
-    // Times New Roman
-    case timesNewRomanPSItalicMT = "TimesNewRomanPS-ItalicMT"
-    case timesNewRomanPSBoldItalicMT = "TimesNewRomanPS-BoldItalicMT"
-    case timesNewRomanPSMT = "TimesNewRomanPSMT"
-    case timesNewRomanPSBoldMT = "TimesNewRomanPS-BoldMT"
-
-    // Trebuchet MS
-    case trebuchetMSItalic = "TrebuchetMS-Italic"
-    case trebuchetMSBold = "TrebuchetMS-Bold"
-    case trebuchetBoldItalic = "Trebuchet-BoldItalic"
-    case trebuchetMS = "TrebuchetMS"
-
-    // Zapf Dingbats
-    case zapfDingbatsITC = "ZapfDingbatsITC"
-    #endif
 }


### PR DESCRIPTION
* Removed duplicate entries by interleaving fonts that are common to both platforms with ones that are found only on one or the other. This shaved off about 200 lines.
* Alphabetized `case` names.
* Added `// MARK`s to make it easier to navigate down the list.

All tests on both iOS and tvOS passed.