### PR TITLE
[Accessibility] Added Dynamic Type support

### DIFF
--- a/Sources/FontRepresentable.swift
+++ b/Sources/FontRepresentable.swift
@@ -49,4 +49,16 @@ extension FontRepresentable where Self.RawValue == String {
 	public func of(size: Double) -> Font {
 		return .custom(rawValue, size: CGFloat(size))
 	}
+
+    /// Creates scalable `UIFont` object that takes current Dynamic Type setting into account.
+    ///
+    /// Make sure that labels using this scaleable font have `adjustsFontForContentSizeCategory` set to `true`.
+    /// - Parameter textStyle: The text style to use for this font.
+    /// - Returns: Scalable `UIFont` object.
+    @available(iOS 11.0, *)
+    public func scaledFont(textStyle: UIFont.TextStyle = .body) -> UIFont? {
+        let defaultSize = UIFont.preferredFont(forTextStyle: textStyle).pointSize
+        guard let font = UIFont(name: rawValue, size: defaultSize) else { return nil }
+        return UIFontMetrics(forTextStyle: textStyle).scaledFont(for: font)
+    }
 }

--- a/Sources/UIFont+Extension.swift
+++ b/Sources/UIFont+Extension.swift
@@ -27,4 +27,18 @@ extension UIFont {
         let fontIdentifier: String = font.rawValue
         self.init(name: fontIdentifier, size: size)
     }
+
+    /// Creates a scaleable `UIFont` from a given `BuiltInFont`.
+    ///
+    /// Make sure that labels using this scaleable font have `adjustsFontForContentSizeCategory` set to `true`.
+    /// - Parameters:
+    ///   - font: The font to use.
+    ///   - textStyle: The text style to use.
+    /// - Returns: A scaleable font object.
+    @available(iOS 11.0, *)
+    public static func scaled(font: BuiltInFont, textStyle: UIFont.TextStyle = .body) -> UIFont? {
+        let defaultSize = UIFont.preferredFont(forTextStyle: textStyle).pointSize
+        guard let font = UIFont(font: font, size: defaultSize) else { return nil }
+        return UIFontMetrics(forTextStyle: textStyle).scaledFont(for: font)
+    }
 }


### PR DESCRIPTION
### Current State
All created `UIFont`s are fixed to a certain size. Creating scalable (Dynamic Type) font objects requires some boilerplate code in the client app importing this package.

### Why Dynamic Type?
For accessibility reasons apps should user scalable (Dynamic Type) fonts rather than ones with fixed font sizes. If users increase/decrease font sizes in their settings, fixed fonts would not change, Dynamic Type fonts would do that.

### Updates
This small addition adds two new methods that make it very easy to create Dynamic Type supporting `UIFont` objects. The methods use the native `UIFont.TextStyle`, the default is `.body`.

### Usage
```swift
// Default is UIFont.TextStyle.body

label.font = UIFont.scaled(font: .avenirMedium)
label.font = BuiltInFont.avenirMedium.scaledFont()

// Example with other text styles

label.font = UIFont.scaled(font: .avenirMedium, textStyle: .headline)
label.font = BuiltInFont.avenirMedium.scaledFont(textStyle: .title3)
```

Quick Demo video in Simulator:

https://user-images.githubusercontent.com/35889530/193431052-9b7dc4bb-793e-4097-9e7b-b39e314ed428.mov


