### PR TITLE
Add CaseIterable to BuiltInFont

### DIFF
--- a/Sources/BuiltInFont.swift
+++ b/Sources/BuiltInFont.swift
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-public enum BuiltInFont: String, FontRepresentable {
+public enum BuiltInFont: String, FontRepresentable, CaseIterable {
 
     // ======== ONLY Available in iOS 13+ ========
     #if os(iOS)


### PR DESCRIPTION
This PR adds CaseIterable conformance to BuiltInFont, so that we can use allCases to get all BuiltInFont cases.